### PR TITLE
Ultrasonic Sensor HC-SR04 with Arduino

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,0 +1,15 @@
+WORKING 
+Ultrasonic Sensor HC-SR04 is a sensor that can measure distance. It emits an ultrasound at 40 000 Hz (40kHz) which travels through the air and if there is an object or obstacle on its path It will bounce back to the module. Considering the travel time and the speed of the sound you can calculate the distance.
+The configuration pin of HC-SR04 is VCC (1), TRIG (2), ECHO (3), and GND (4). The supply voltage of VCC is +5V and you can attach TRIG and ECHO pin to any Digital I/O in 
+your Arduino Board.
+
+CONNECTION 
+5v-VCC
+GND-GND
+D2-ECHO
+D3-TRIG
+
+COMPONENTS REQUIRED
+1. Arduino UNO R3 
+2. Male to FEMale Jumper Wires
+3. Ultrasonic Sensor HC-SR04


### PR DESCRIPTION
Ultrasonic Sensor HC-SR04 with Arduino Tutorial
WORKING 
Ultrasonic Sensor HC-SR04 is a sensor that can measure distance. It emits an ultrasound at 40 000 Hz (40kHz) which travels through the air and if there is an object or obstacle on its path It will bounce back to the module. Considering the travel time and the speed of the sound you can calculate the distance.
The configuration pin of HC-SR04 is VCC (1), TRIG (2), ECHO (3), and GND (4). The supply voltage of VCC is +5V and you can attach TRIG and ECHO pin to any Digital I/O in 
your Arduino Board.

CONNECTION 
5v-VCC
GND-GND
D2-ECHO
D3-TRIG

COMPONENTS REQUIRED
1. Arduino UNO R3 
2. Male to FEMale Jumper Wires
3. Ultrasonic Sensor HC-SR04
